### PR TITLE
Change emitted event's name to avoid autocompletion being fired twice

### DIFF
--- a/ga-search.js
+++ b/ga-search.js
@@ -130,7 +130,7 @@ class GeoadminSearch extends LitElement {
 
       onSubmit: result => {
         if (result) {
-          this.dispatchEvent(new CustomEvent('submit', {
+          this.dispatchEvent(new CustomEvent('ga-submit', {
             bubbles: true,
             composed: true,
             detail: {


### PR DESCRIPTION
Event name collision with the autocomplete library causes autocompletion to be fired again when an item is already chosen